### PR TITLE
Unpin Serverless version

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -19,10 +19,6 @@ service: gis-addresses-api-proxy
 plugins:
   - serverless-dotenv-plugin
 
-# You can pin your service to only deploy with a specific Serverless version
-# Check out our docs for more details
-frameworkVersion: '2'
-
 
 provider:
   name: aws


### PR DESCRIPTION
This pull request removes the `frameworkVersion` configuration in the `serverless.yml` file, which previously pinned the service to deploy with a specific Serverless version (version 2). Now it should use the most up-to-date version (version 4), which matches other Hackney projects 😄 